### PR TITLE
Use try-with-resource to make sure resources are properly closed.

### DIFF
--- a/DataTransfer/src/main/java/fr/elimerl/registre/transfer/DataTransfer.java
+++ b/DataTransfer/src/main/java/fr/elimerl/registre/transfer/DataTransfer.java
@@ -38,9 +38,7 @@ public class DataTransfer {
      */
     public static void main(final String[] args) {
 	removeAtGenerated();
-	ClassPathXmlApplicationContext ctx = null;
-	try {
-	    ctx = new ClassPathXmlApplicationContext("applicationContext.xml");
+	try (ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("applicationContext.xml")) {
 	    final DataTransfer main =
 		    ctx.getBean("main", DataTransfer.class);
 	    main.migrateAllRecords();
@@ -49,10 +47,6 @@ public class DataTransfer {
 	    if (e.getCause() instanceof FileNotFoundException) {
 		System.err.println("There mus be a config.properties file in"
 			+ " the classpath.");
-	    }
-	} finally {
-	    if (ctx != null) {
-		ctx.close();
 	    }
 	}
     }

--- a/DataTransfer/src/main/java/fr/elimerl/registre/transfer/MigratorImpl.java
+++ b/DataTransfer/src/main/java/fr/elimerl/registre/transfer/MigratorImpl.java
@@ -156,24 +156,24 @@ public class MigratorImpl implements Migrator {
 	int migrated = 0;
 	recordsQuery.setInt(1, first);
 	recordsQuery.setInt(2, number);
-	final ResultSet result = recordsQuery.executeQuery();
-	while (result.next()) {
-	    final String type = result.getString("type");
-	    final Record record;
-	    if (type.equals("livre")) {
-		record = createBook(result);
-	    } else if (type.equals("BD")) {
-		record = createComic(result);
-	    } else { // Movie. Type Blu-ray, DVD or "cassette".
-		record = createMovie(result);
-	    }
-	    fillInCommonFields(record, result);
-	    final Record savedRecord = jpaEntityManager.merge(record);
-	    index.reindex(savedRecord);
-	    logger.debug("{} migrated.", savedRecord);
-	    migrated++;
-	}
-	result.close();
+	try (ResultSet result = recordsQuery.executeQuery()) {
+            while (result.next()) {
+                final String type = result.getString("type");
+                final Record record;
+                if (type.equals("livre")) {
+                    record = createBook(result);
+                } else if (type.equals("BD")) {
+                    record = createComic(result);
+                } else { // Movie. Type Blu-ray, DVD or "cassette".
+                    record = createMovie(result);
+                }
+                fillInCommonFields(record, result);
+                final Record savedRecord = jpaEntityManager.merge(record);
+                index.reindex(savedRecord);
+                logger.debug("{} migrated.", savedRecord);
+                migrated++;
+            }
+        }
 	return migrated;
     }
 
@@ -287,12 +287,12 @@ public class MigratorImpl implements Migrator {
 	    );
 	}
 	actorsQuery.setInt(1, id);
-	final ResultSet acteurs = actorsQuery.executeQuery();
-	while (acteurs.next()) {
-	    final String nom = acteurs.getString("acteur");
-	    movie.getActors().add(registreEntityManager.supplyActor(nom));
-	}
-	acteurs.close();
+	try (ResultSet acteurs = actorsQuery.executeQuery()) {
+            while (acteurs.next()) {
+                final String nom = acteurs.getString("acteur");
+                movie.getActors().add(registreEntityManager.supplyActor(nom));
+            }
+        }
 	return movie;
     }
 


### PR DESCRIPTION
Using `try-with-resources` makes closing resources easier. This statement was introduced in Java 7, while most of the code was written for Java 6.

This being said, the unavailability of the `try-with-resources` statement was no excuse not to close `ResultSet`s when an exception was thrown. My bad.

Closes #2.