### PR TITLE
Make the DataTransfer jar runnable

### DIFF
--- a/DataTransfer/build.gradle
+++ b/DataTransfer/build.gradle
@@ -1,3 +1,6 @@
+plugins {
+  id 'com.github.johnrengelman.shadow' version '2.0.1'
+}
 
 description = ''
 dependencies {
@@ -6,4 +9,8 @@ dependencies {
   compile group: 'org.springframework', name: 'spring-orm', version:'4.0.2.RELEASE'
   compile group: 'org.javassist', name: 'javassist', version:'3.19.0-GA'
   compile group: 'javax', name: 'javaee-web-api', version:'7.0'
+}
+
+assemble {
+  dependsOn shadowJar
 }

--- a/DataTransfer/build.gradle
+++ b/DataTransfer/build.gradle
@@ -11,6 +11,12 @@ dependencies {
   compile group: 'javax', name: 'javaee-web-api', version:'7.0'
 }
 
+jar {
+  manifest {
+    attributes 'Main-Class': 'fr.elimerl.registre.transfer.DataTransfer'
+  }
+}
+
 assemble {
   dependsOn shadowJar
 }

--- a/DataTransfer/build.gradle
+++ b/DataTransfer/build.gradle
@@ -17,6 +17,12 @@ jar {
   }
 }
 
+shadowJar {
+  mergeServiceFiles {
+    include 'META-INF/spring.*'
+  }
+}
+
 assemble {
   dependsOn shadowJar
 }

--- a/DataTransfer/src/main/java/fr/elimerl/registre/transfer/MigratorImpl.java
+++ b/DataTransfer/src/main/java/fr/elimerl/registre/transfer/MigratorImpl.java
@@ -77,19 +77,19 @@ public class MigratorImpl implements Migrator {
     /**
      * Registre’s former database.
      */
-    @Resource(name = "ancienneBase")
+    @Resource(name = "oldDb")
     private DataSource formerDatabase;
 
     /**
      * Registre entity manager. Will be used to create all {@link Named}s.
      */
-    @Resource(name = "gestionnaireEntités")
+    @Resource(name = "registreEntityManager")
     private RegistreEntityManager registreEntityManager;
 
     /**
      * Service used to index records.
      */
-    @Resource(name = "indexeur")
+    @Resource(name = "index")
     private Index index;
 
     /**

--- a/DataTransfer/src/main/java/fr/elimerl/registre/transfer/MigratorImpl.java
+++ b/DataTransfer/src/main/java/fr/elimerl/registre/transfer/MigratorImpl.java
@@ -334,11 +334,11 @@ public class MigratorImpl implements Migrator {
 	    record.toucher(provideUser(lastModifier));
 	}
 	defineField(record, "id", new Long(id));
-	defineField(record, "création", creation);
+	defineField(record, "creation", creation);
 	if (lastModification == null) {
-	    defineField(record, "dernièreÉdition", creation);
+	    defineField(record, "lastModification", creation);
 	} else {
-	    defineField(record, "dernièreÉdition", lastModification);
+	    defineField(record, "lastModification", lastModification);
 	}
     }
 

--- a/DataTransfer/src/main/resources/applicationContext.xml
+++ b/DataTransfer/src/main/resources/applicationContext.xml
@@ -18,33 +18,33 @@
 
   <context:property-placeholder location="classpath:config.properties"/>
 
-  <bean id="gestionnaireEntités"
+  <bean id="registreEntityManager"
     class="fr.elimerl.registre.services.RegistreEntityManager"/>
 
-  <bean id="indexeur" class="fr.elimerl.registre.services.Index"/>
+  <bean id="index" class="fr.elimerl.registre.services.Index"/>
 
-  <bean id="gestionnaireTransactions" class="org.springframework.orm.jpa.JpaTransactionManager"/>
+  <bean id="transactionManager" class="org.springframework.orm.jpa.JpaTransactionManager"/>
 
-  <tx:annotation-driven transaction-manager="gestionnaireTransactions"/>
+  <tx:annotation-driven/>
 
-  <bean id="usineGestionnaireEntitésJpa"
+  <bean id="jpaEntityManagerFactory"
       class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
-    <property name="dataSource" ref="nouvelleBase"/>
+    <property name="dataSource" ref="newDb"/>
     <property name="persistenceUnitName" value="Registre" />
   </bean>
 
-  <bean id="ancienneBase" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
-    <property name="driverClass" value="${ancienneBase.pilote}"/>
-    <property name="url" value="${ancienneBase.url}"/>
-    <property name="username" value="${ancienneBase.utilisateur}"/>
-    <property name="password" value="${ancienneBase.mdp}"/>
+  <bean id="oldDb" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+    <property name="driverClass" value="${oldDb.driver}"/>
+    <property name="url" value="${oldDb.url}"/>
+    <property name="username" value="${oldDb.user}"/>
+    <property name="password" value="${oldDb.pwd}"/>
   </bean>
 
-  <bean id="nouvelleBase" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
-    <property name="driverClass" value="${nouvelleBase.pilote}"/>
-    <property name="url" value="${nouvelleBase.url}"/>
-    <property name="username" value="${nouvelleBase.utilisateur}"/>
-    <property name="password" value="${nouvelleBase.mdp}"/>
+  <bean id="newDb" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">
+    <property name="driverClass" value="${newDb.driver}"/>
+    <property name="url" value="${newDb.url}"/>
+    <property name="username" value="${newDb.user}"/>
+    <property name="password" value="${newDb.pwd}"/>
   </bean>
 
   <bean id="main" class="fr.elimerl.registre.transfer.DataTransfer">


### PR DESCRIPTION
There were two issues here:

1. The Maven to Gradle migration (dcf4782e283b9b5573936c0af26f1a10c6a01643) didn’t port the shade plugin. Hence, the DataTransfer jar (formerly “RepriseDeDonnées” jar) didn’t include the required dependencies.
2. Running the jar revealed that a number of translations were forgotten in #6. Thus, some field or bean names mismatched.

Fixes #12.