### PR TITLE
Use Nebula Dependency Recommender plugin

### DIFF
--- a/DataTransfer/build.gradle
+++ b/DataTransfer/build.gradle
@@ -5,16 +5,16 @@ plugins {
 description = ''
 dependencies {
   compile project(':Model')
-  compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
-  compile group: 'org.springframework', name: 'spring-context', version: springVersion
+  compile group: 'org.slf4j', name: 'slf4j-api'
+  compile group: 'org.springframework', name: 'spring-context'
   compile group: 'org.javassist', name: 'javassist', version:'3.22.0-GA'
   compile group: 'javax', name: 'javaee-web-api', version:'7.0'
-  runtime group: 'org.springframework', name: 'spring-orm', version: springVersion
-  testCompile group: 'junit', name: 'junit', version: junitVersion
-  testCompile group: 'org.springframework', name: 'spring-jdbc', version: springVersion
-  testCompile group: 'org.assertj', name: 'assertj-core', version: assertjVersion
-  testRuntime group: 'org.hsqldb', name: 'hsqldb', version: hsqldbVersion
-  testRuntime group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
+  runtime group: 'org.springframework', name: 'spring-orm'
+  testCompile group: 'junit', name: 'junit'
+  testCompile group: 'org.springframework', name: 'spring-jdbc'
+  testCompile group: 'org.assertj', name: 'assertj-core'
+  testRuntime group: 'org.hsqldb', name: 'hsqldb'
+  testRuntime group: 'org.slf4j', name: 'slf4j-log4j12'
   testRuntime files(project(':Model').file('src/main/sql'))
 }
 

--- a/DataTransfer/build.gradle
+++ b/DataTransfer/build.gradle
@@ -7,8 +7,8 @@ dependencies {
   compile project(':Model')
   compile group: 'org.slf4j', name: 'slf4j-api'
   compile group: 'org.springframework', name: 'spring-context'
-  compile group: 'org.javassist', name: 'javassist', version:'3.22.0-GA'
-  compile group: 'javax', name: 'javaee-web-api', version:'7.0'
+  compile group: 'org.javassist', name: 'javassist'
+  compile group: 'javax', name: 'javaee-web-api'
   runtime group: 'org.springframework', name: 'spring-orm'
   testCompile group: 'junit', name: 'junit'
   testCompile group: 'org.springframework', name: 'spring-jdbc'

--- a/Model/build.gradle
+++ b/Model/build.gradle
@@ -1,13 +1,13 @@
 
 description = 'Modèle Registre'
 dependencies {
-    compile group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.jpa', version:'2.7.0'
+    compile group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.jpa'
     compile group: 'org.slf4j', name: 'slf4j-api'
     testCompile group: 'junit', name: 'junit'
     testCompile group: 'org.mockito', name: 'mockito-core'
     testCompile group: 'org.slf4j', name: 'slf4j-log4j12'
     testCompile group: 'org.slf4j', name: 'jul-to-slf4j'
-    testCompile group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version:'2.4'
+    testCompile group: 'nl.jqno.equalsverifier', name: 'equalsverifier'
     testCompile group: 'org.springframework', name: 'spring-test'
     testCompile group: 'org.springframework', name: 'spring-context'
     testCompile group: 'org.springframework', name: 'spring-orm'

--- a/Model/build.gradle
+++ b/Model/build.gradle
@@ -2,16 +2,16 @@
 description = 'Modèle Registre'
 dependencies {
     compile group: 'org.eclipse.persistence', name: 'org.eclipse.persistence.jpa', version:'2.7.0'
-    compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
-    testCompile group: 'junit', name: 'junit', version: junitVersion
-    testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
-    testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
-    testCompile group: 'org.slf4j', name: 'jul-to-slf4j', version: slf4jVersion
+    compile group: 'org.slf4j', name: 'slf4j-api'
+    testCompile group: 'junit', name: 'junit'
+    testCompile group: 'org.mockito', name: 'mockito-core'
+    testCompile group: 'org.slf4j', name: 'slf4j-log4j12'
+    testCompile group: 'org.slf4j', name: 'jul-to-slf4j'
     testCompile group: 'nl.jqno.equalsverifier', name: 'equalsverifier', version:'2.4'
-    testCompile group: 'org.springframework', name: 'spring-test', version: springVersion
-    testCompile group: 'org.springframework', name: 'spring-context', version: springVersion
-    testCompile group: 'org.springframework', name: 'spring-orm', version: springVersion
-    testCompile group: 'org.hsqldb', name: 'hsqldb', version: hsqldbVersion
+    testCompile group: 'org.springframework', name: 'spring-test'
+    testCompile group: 'org.springframework', name: 'spring-context'
+    testCompile group: 'org.springframework', name: 'spring-orm'
+    testCompile group: 'org.hsqldb', name: 'hsqldb'
 }
 processTestResources {
     expand(basedir: "$rootDir/Model")

--- a/Security/build.gradle
+++ b/Security/build.gradle
@@ -2,14 +2,14 @@
 description = 'Registre Sécurité'
 dependencies {
   compile project(':Model')
-  compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
+  compile group: 'org.slf4j', name: 'slf4j-api'
   compile group: 'org.mitre', name: 'openid-connect-client', version: '1.3.1'
-  testCompile group: 'junit', name: 'junit', version: junitVersion
-  testCompile group: 'org.assertj', name: 'assertj-core', version: assertjVersion
-  testCompile group: 'org.mockito', name: 'mockito-core', version: mockitoVersion
-  testCompile group: 'org.slf4j', name: 'slf4j-log4j12', version: slf4jVersion
-  testRuntime group: 'org.springframework', name: 'spring-orm', version: springVersion
-  testRuntime group: 'org.hsqldb', name: 'hsqldb', version: hsqldbVersion
+  testCompile group: 'junit', name: 'junit'
+  testCompile group: 'org.assertj', name: 'assertj-core'
+  testCompile group: 'org.mockito', name: 'mockito-core'
+  testCompile group: 'org.slf4j', name: 'slf4j-log4j12'
+  testRuntime group: 'org.springframework', name: 'spring-orm'
+  testRuntime group: 'org.hsqldb', name: 'hsqldb'
 }
 
 processTestResources {

--- a/Security/build.gradle
+++ b/Security/build.gradle
@@ -3,7 +3,7 @@ description = 'Registre Sécurité'
 dependencies {
   compile project(':Model')
   compile group: 'org.slf4j', name: 'slf4j-api'
-  compile group: 'org.mitre', name: 'openid-connect-client', version: '1.3.1'
+  compile group: 'org.mitre', name: 'openid-connect-client'
   testCompile group: 'junit', name: 'junit'
   testCompile group: 'org.assertj', name: 'assertj-core'
   testCompile group: 'org.mockito', name: 'mockito-core'

--- a/Server/build.gradle
+++ b/Server/build.gradle
@@ -5,13 +5,13 @@ description = 'Serveur Registre'
 dependencies {
   compile project(':Model')
   compile project(':Security')
-  compile group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion
-  compile group: 'org.springframework', name: 'spring-context', version: springVersion
-  compile group: 'org.springframework', name: 'spring-webmvc', version: springVersion
-  compile group: 'org.springframework', name: 'spring-context-support', version: springVersion
-  compile group: 'org.springframework', name: 'spring-orm', version: springVersion
-  compile group: 'org.springframework.security', name: 'spring-security-config', version: springSecurityVersion
-  compile group: 'org.springframework.security', name: 'spring-security-web', version: springSecurityVersion
+  compile group: 'org.slf4j', name: 'slf4j-api'
+  compile group: 'org.springframework', name: 'spring-context'
+  compile group: 'org.springframework', name: 'spring-webmvc'
+  compile group: 'org.springframework', name: 'spring-context-support'
+  compile group: 'org.springframework', name: 'spring-orm'
+  compile group: 'org.springframework.security', name: 'spring-security-config'
+  compile group: 'org.springframework.security', name: 'spring-security-web'
   compileOnly group: 'javax', name: 'javaee-web-api', version:'7.0'
   runtime group: 'org.apache.velocity', name: 'velocity', version:'1.7'
 }

--- a/Server/build.gradle
+++ b/Server/build.gradle
@@ -12,8 +12,8 @@ dependencies {
   compile group: 'org.springframework', name: 'spring-orm'
   compile group: 'org.springframework.security', name: 'spring-security-config'
   compile group: 'org.springframework.security', name: 'spring-security-web'
-  compileOnly group: 'javax', name: 'javaee-web-api', version:'7.0'
-  runtime group: 'org.apache.velocity', name: 'velocity', version:'1.7'
+  compileOnly group: 'javax', name: 'javaee-web-api'
+  runtime group: 'org.apache.velocity', name: 'velocity'
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -5,11 +5,11 @@ plugins {
 allprojects  {
   group = 'fr.elimerl.Registre'
   version = '3.0-SNAPSHOT'
+  apply plugin: 'nebula.dependency-recommender'
 }
 
 subprojects {
   apply plugin: 'java'
-  apply plugin: 'nebula.dependency-recommender'
 
   sourceCompatibility = 1.8
   targetCompatibility = 1.8

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ subprojects {
   }
 
   dependencyRecommendations {
-    propertiesFile file: parent.file ('dependencyVersions')
+    propertiesFile file: rootProject.file ('dependencyVersions')
     mavenBom module: [group: 'org.springframework', name: 'spring-framework-bom', ext: 'pom']
     mavenBom module: [group: 'org.springframework.security', name: 'spring-security-bom', ext: 'pom']
   }

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+  id 'nebula.dependency-recommender' version '5.0.0' apply false
+}
+
 allprojects  {
   group = 'fr.elimerl.Registre'
   version = '3.0-SNAPSHOT'
@@ -5,6 +9,8 @@ allprojects  {
 
 subprojects {
   apply plugin: 'java'
+  apply plugin: 'nebula.dependency-recommender'
+
   sourceCompatibility = 1.8
   targetCompatibility = 1.8
 
@@ -12,14 +18,9 @@ subprojects {
     mavenCentral()
   }
 
-}
-
-ext {
-  springVersion = '4.3.12.RELEASE'
-  slf4jVersion = '1.7.15'
-  junitVersion = '4.12'
-  springSecurityVersion = '4.2.3.RELEASE'
-  mockitoVersion = '2.12.0'
-  hsqldbVersion = '2.4.0'
-  assertjVersion = '3.8.0'
+  dependencyRecommendations {
+    propertiesFile file: parent.file ('dependencyVersions')
+    mavenBom module: [group: 'org.springframework', name: 'spring-framework-bom', ext: 'pom']
+    mavenBom module: [group: 'org.springframework.security', name: 'spring-security-bom', ext: 'pom']
+  }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ subprojects {
   }
 
   dependencyRecommendations {
+    strategy OverrideTransitives
     propertiesFile file: rootProject.file ('dependencyVersions')
     mavenBom module: [group: 'org.springframework', name: 'spring-framework-bom']
     mavenBom module: [group: 'org.springframework.security', name: 'spring-security-bom']

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ subprojects {
 
   dependencyRecommendations {
     propertiesFile file: rootProject.file ('dependencyVersions')
-    mavenBom module: [group: 'org.springframework', name: 'spring-framework-bom', ext: 'pom']
-    mavenBom module: [group: 'org.springframework.security', name: 'spring-security-bom', ext: 'pom']
+    mavenBom module: [group: 'org.springframework', name: 'spring-framework-bom']
+    mavenBom module: [group: 'org.springframework.security', name: 'spring-security-bom']
   }
 }

--- a/dependencyVersions
+++ b/dependencyVersions
@@ -5,7 +5,14 @@ org.slf4j:slf4j-api = 1.7.15
 org.slf4j:slf4j-log4j12 = $org.slf4j:slf4j-api
 org.slf4j:jul-to-slf4j = $org.slf4j:slf4j-api
 
+org.javassist:javassist = 3.22.0-GA
+javax:javaee-web-api = 7.0
+org.eclipse.persistence:org.eclipse.persistence.jpa = 2.7.0
+org.mitre:openid-connect-client = 1.3.1
+org.apache.velocity:velocity = 1.7
+
 junit:junit = 4.12
 org.mockito:mockito-core = 2.12.0
 org.hsqldb:hsqldb = 2.4.0
 org.assertj:assertj-core = 3.8.0
+nl.jqno.equalsverifier:equalsverifier = 2.4

--- a/dependencyVersions
+++ b/dependencyVersions
@@ -1,0 +1,11 @@
+org.springframework:spring-framework-bom = 4.3.12.RELEASE
+org.springframework.security:spring-security-bom = 4.2.3.RELEASE
+
+org.slf4j:slf4j-api = 1.7.15
+org.slf4j:slf4j-log4j12 = $org.slf4j:slf4j-api
+org.slf4j:jul-to-slf4j = $org.slf4j:slf4j-api
+
+junit:junit = 4.12
+org.mockito:mockito-core = 2.12.0
+org.hsqldb:hsqldb = 2.4.0
+org.assertj:assertj-core = 3.8.0


### PR DESCRIPTION
The [Nebula Dependency Recommender][1] plugin allows to specify in one place the versions of all dependencies, including transitive ones.

Resolves #25.

[1]: https://github.com/nebula-plugins/nebula-dependency-recommender-plugin