### PR TITLE
Keep the records IDs when migrating

### DIFF
--- a/DataTransfer/build.gradle
+++ b/DataTransfer/build.gradle
@@ -7,7 +7,6 @@ dependencies {
   compile project(':Model')
   compile group: 'org.slf4j', name: 'slf4j-api'
   compile group: 'org.springframework', name: 'spring-context'
-  compile group: 'org.javassist', name: 'javassist'
   compile group: 'javax', name: 'javaee-web-api'
   runtime group: 'org.springframework', name: 'spring-orm'
   testCompile group: 'junit', name: 'junit'

--- a/DataTransfer/src/main/java/fr/elimerl/registre/transfer/DataTransfer.java
+++ b/DataTransfer/src/main/java/fr/elimerl/registre/transfer/DataTransfer.java
@@ -1,13 +1,5 @@
 package fr.elimerl.registre.transfer;
 
-import javassist.CannotCompileException;
-import javassist.ClassPool;
-import javassist.CtClass;
-import javassist.CtField;
-import javassist.NotFoundException;
-import javassist.bytecode.AnnotationsAttribute;
-import javassist.bytecode.FieldInfo;
-import javassist.bytecode.annotation.Annotation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanInitializationException;
@@ -35,7 +27,6 @@ public class DataTransfer {
    *     not used.
    */
   public static void main (final String[] args) {
-    removeAtGenerated ();
     try (ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext ("applicationContext.xml")) {
       final DataTransfer main =
           ctx.getBean ("main", DataTransfer.class);
@@ -46,45 +37,6 @@ public class DataTransfer {
         System.err.println ("There mus be a config.properties file in"
             + " the classpath.");
       }
-    }
-  }
-
-  /**
-   * Removes the {@code @Generated} annotation from the {@code Record} class
-   * id. This allows us to keep the id of migrated records.
-   */
-  private static void removeAtGenerated () {
-    try {
-      final ClassPool pool = ClassPool.getDefault ();
-      final CtClass record = pool.get ("fr.elimerl.registre.entities.Record");
-      final CtField id = record.getDeclaredField ("id");
-      final FieldInfo info = id.getFieldInfo ();
-      final AnnotationsAttribute attribute = (AnnotationsAttribute)
-          info.getAttribute (AnnotationsAttribute.visibleTag);
-      final Annotation[] oldAnnotations =
-          attribute.getAnnotations ();
-      final Annotation[] newAnnotations =
-          new Annotation[oldAnnotations.length - 1];
-      int i = 0;
-      for (final Annotation annotation : oldAnnotations) {
-        if (!annotation.getTypeName ().equals (
-            "javax.persistence.GeneratedValue")) {
-          newAnnotations[i] = annotation;
-          i++;
-        }
-      }
-      attribute.setAnnotations (newAnnotations);
-      record.toClass ();
-    } catch (final NotFoundException e) {
-      final String message =
-          "Could not find the Record class or is id field.";
-      logger.error (message);
-      throw new RuntimeException (message, e);
-    } catch (final CannotCompileException e) {
-      final String message =
-          "Could not compile the new Record class.";
-      logger.error (message);
-      throw new RuntimeException (message, e);
     }
   }
 
@@ -100,7 +52,7 @@ public class DataTransfer {
   /**
    * Main method of this application, it requests handling of each records.
    */
-  public void migrateAllRecords () {
+  private void migrateAllRecords () {
     int number = batchSize;
     int i = 0;
     logger.info ("Starting migration.");

--- a/DataTransfer/src/main/java/fr/elimerl/registre/transfer/DataTransfer.java
+++ b/DataTransfer/src/main/java/fr/elimerl/registre/transfer/DataTransfer.java
@@ -1,8 +1,5 @@
 package fr.elimerl.registre.transfer;
 
-import java.io.FileNotFoundException;
-import java.sql.SQLException;
-
 import javassist.CannotCompileException;
 import javassist.ClassPool;
 import javassist.CtClass;
@@ -11,122 +8,123 @@ import javassist.NotFoundException;
 import javassist.bytecode.AnnotationsAttribute;
 import javassist.bytecode.FieldInfo;
 import javassist.bytecode.annotation.Annotation;
-
-import javax.annotation.Resource;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanInitializationException;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.stereotype.Service;
 
+import javax.annotation.Resource;
+import java.io.FileNotFoundException;
+import java.sql.SQLException;
+
 /**
  * Main class of the data transfer program.
  */
-@Service("main")
+@Service ("main")
 public class DataTransfer {
 
-    /** SLF4J logger for this class. */
-    private static final Logger logger =
-	    LoggerFactory.getLogger(DataTransfer.class);
+  /** SLF4J logger for this class. */
+  private static final Logger logger =
+      LoggerFactory.getLogger (DataTransfer.class);
 
-    /**
-     * Method responsible for launching this application.
-     *
-     * @param args
-     *            not used.
-     */
-    public static void main(final String[] args) {
-	removeAtGenerated();
-	try (ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext("applicationContext.xml")) {
-	    final DataTransfer main =
-		    ctx.getBean("main", DataTransfer.class);
-	    main.migrateAllRecords();
-	} catch (final BeanInitializationException e) {
-	    logger.error("Impossible to instantiate context.", e);
-	    if (e.getCause() instanceof FileNotFoundException) {
-		System.err.println("There mus be a config.properties file in"
-			+ " the classpath.");
-	    }
-	}
+  /**
+   * Method responsible for launching this application.
+   *
+   * @param args
+   *     not used.
+   */
+  public static void main (final String[] args) {
+    removeAtGenerated ();
+    try (ClassPathXmlApplicationContext ctx = new ClassPathXmlApplicationContext ("applicationContext.xml")) {
+      final DataTransfer main =
+          ctx.getBean ("main", DataTransfer.class);
+      main.migrateAllRecords ();
+    } catch (final BeanInitializationException e) {
+      logger.error ("Impossible to instantiate context.", e);
+      if (e.getCause () instanceof FileNotFoundException) {
+        System.err.println ("There mus be a config.properties file in"
+            + " the classpath.");
+      }
     }
+  }
 
-    /**
-     * Removes the {@code @Generated} annotation from the {@code Record} class
-     * id. This allows us to keep the id of migrated records.
-     */
-    private static void removeAtGenerated() {
-	try {
-	    final ClassPool pool = ClassPool.getDefault();
-	    final CtClass record = pool.get("fr.elimerl.registre.entities.Record");
-	    final CtField id = record.getDeclaredField("id");
-	    final FieldInfo info = id.getFieldInfo();
-	    final AnnotationsAttribute attribute = (AnnotationsAttribute)
-		    info.getAttribute(AnnotationsAttribute.visibleTag);
-	    final Annotation[] oldAnnotations =
-		    attribute.getAnnotations();
-	    final Annotation[] newAnnotations =
-		    new Annotation[oldAnnotations.length - 1];
-	    int i = 0;
-	    for (final Annotation annotation : oldAnnotations) {
-		if (!annotation.getTypeName().equals(
-			"javax.persistence.GeneratedValue")) {
-		    newAnnotations[i] = annotation;
-		    i++;
-		}
-	    }
-	    attribute.setAnnotations(newAnnotations);
-	    record.toClass();
-	} catch (final NotFoundException e) {
-	    final String message =
-		    "Could not find the Record class or is id field.";
-	    logger.error(message);
-	    throw new RuntimeException(message, e);
-	} catch (final CannotCompileException e) {
-	    final String message =
-		    "Could not compile the new Record class.";
-	    logger.error(message);
-	    throw new RuntimeException(message, e);
-	}
+  /**
+   * Removes the {@code @Generated} annotation from the {@code Record} class
+   * id. This allows us to keep the id of migrated records.
+   */
+  private static void removeAtGenerated () {
+    try {
+      final ClassPool pool = ClassPool.getDefault ();
+      final CtClass record = pool.get ("fr.elimerl.registre.entities.Record");
+      final CtField id = record.getDeclaredField ("id");
+      final FieldInfo info = id.getFieldInfo ();
+      final AnnotationsAttribute attribute = (AnnotationsAttribute)
+          info.getAttribute (AnnotationsAttribute.visibleTag);
+      final Annotation[] oldAnnotations =
+          attribute.getAnnotations ();
+      final Annotation[] newAnnotations =
+          new Annotation[oldAnnotations.length - 1];
+      int i = 0;
+      for (final Annotation annotation : oldAnnotations) {
+        if (!annotation.getTypeName ().equals (
+            "javax.persistence.GeneratedValue")) {
+          newAnnotations[i] = annotation;
+          i++;
+        }
+      }
+      attribute.setAnnotations (newAnnotations);
+      record.toClass ();
+    } catch (final NotFoundException e) {
+      final String message =
+          "Could not find the Record class or is id field.";
+      logger.error (message);
+      throw new RuntimeException (message, e);
+    } catch (final CannotCompileException e) {
+      final String message =
+          "Could not compile the new Record class.";
+      logger.error (message);
+      throw new RuntimeException (message, e);
     }
+  }
 
-    /** Number of records to handle in a single transaction. */
-    private int batchSize;
+  /** Number of records to handle in a single transaction. */
+  private int batchSize;
 
-    /**
-     * Service responsible for migrating each batch of records.
-     */
-    @Resource(name = "migrator")
-    private Migrator migrator;
+  /**
+   * Service responsible for migrating each batch of records.
+   */
+  @Resource (name = "migrator")
+  private Migrator migrator;
 
-    /**
-     * Main method of this application, it requests handling of each records.
-     */
-    public void migrateAllRecords() {
-	int number = batchSize;
-	int i = 0;
-	logger.info("Starting migration.");
-	while (number > 0) {
-	    try {
-		number = migrator.migrateRecords(i, batchSize);
-		i += number;
-		logger.info("{} records migrated.", new Integer(i));
-	    } catch (final SQLException e) {
-		number = 0;
-		logger.error("An SQL error prevents us from going on.", e);
-	    }
-	}
-	logger.info("Migration over.");
+  /**
+   * Main method of this application, it requests handling of each records.
+   */
+  public void migrateAllRecords () {
+    int number = batchSize;
+    int i = 0;
+    logger.info ("Starting migration.");
+    while (number > 0) {
+      try {
+        number = migrator.migrateRecords (i, batchSize);
+        i += number;
+        logger.info ("{} records migrated.", new Integer (i));
+      } catch (final SQLException e) {
+        number = 0;
+        logger.error ("An SQL error prevents us from going on.", e);
+      }
     }
+    logger.info ("Migration over.");
+  }
 
-    /**
-     * Set the number of records to handle in a single transaction.
-     *
-     * @param batchSize
-     *            number of records to migrate in a single transaction.
-     */
-    public void setBatchSize(final int batchSize) {
-	this.batchSize = batchSize;
-    }
+  /**
+   * Set the number of records to handle in a single transaction.
+   *
+   * @param batchSize
+   *     number of records to migrate in a single transaction.
+   */
+  public void setBatchSize (final int batchSize) {
+    this.batchSize = batchSize;
+  }
 
 }

--- a/DataTransfer/src/main/resources/META-INF/orm.xml
+++ b/DataTransfer/src/main/resources/META-INF/orm.xml
@@ -1,0 +1,14 @@
+<entity-mappings
+    xmlns="http://xmlns.jcp.org/xml/ns/persistence/orm"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/persistence/orm
+      http://xmlns.jcp.org/xml/ns/persistence/orm_2_1.xsd"
+    version="2.1">
+  <entity class="fr.elimerl.registre.entities.Record">
+    <attributes>
+      <id name="id">
+        <column name="id"/>
+      </id>
+    </attributes>
+  </entity>
+</entity-mappings>

--- a/DataTransfer/src/main/resources/META-INF/transfer-persistence.xml
+++ b/DataTransfer/src/main/resources/META-INF/transfer-persistence.xml
@@ -1,0 +1,44 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+    version="2.0">
+  <persistence-unit name="Registre">
+    <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+    <mapping-file>META-INF/orm.xml</mapping-file>
+
+    <!-- Classes to persist. -->
+    <class>fr.elimerl.registre.entities.Actor</class>
+    <class>fr.elimerl.registre.entities.Author</class>
+    <class>fr.elimerl.registre.entities.Comic</class>
+    <class>fr.elimerl.registre.entities.Composer</class>
+    <class>fr.elimerl.registre.entities.Cartoonist</class>
+    <class>fr.elimerl.registre.entities.Location</class>
+    <class>fr.elimerl.registre.entities.Record</class>
+    <class>fr.elimerl.registre.entities.Movie</class>
+    <class>fr.elimerl.registre.entities.Book</class>
+    <class>fr.elimerl.registre.entities.Word</class>
+    <class>fr.elimerl.registre.entities.Named</class>
+    <class>fr.elimerl.registre.entities.Owner</class>
+    <class>fr.elimerl.registre.entities.Director</class>
+    <class>fr.elimerl.registre.entities.Reference</class>
+    <class>fr.elimerl.registre.entities.ScriptWriter</class>
+    <class>fr.elimerl.registre.entities.Series</class>
+    <class>fr.elimerl.registre.entities.Session</class>
+    <class>fr.elimerl.registre.entities.User</class>
+    <exclude-unlisted-classes/>
+
+    <properties>
+      <property name="eclipselink.weaving" value="false"/>
+      <property name="eclipselink.id-validation" value="NULL"/>
+      <property name="eclipselink.logging.logger" value="fr.elimerl.registre.logging.Slf4jSessionLogger"/>
+      <property name="eclipselink.logging.level" value="FINEST"/>
+      <property name="eclipselink.logging.sql" value="FINEST"/>
+      <property name="eclipselink.logging.level.sql" value="FINEST"/>
+      <property name="eclipselink.logging.parameters" value="true"/>
+      <property name="eclipselink.logging.timestamp" value="false"/>
+      <property name="eclipselink.logging.thread" value="false"/>
+      <property name="eclipselink.logging.session" value="false"/>
+    </properties>
+
+  </persistence-unit>
+
+</persistence>

--- a/DataTransfer/src/main/resources/applicationContext.xml
+++ b/DataTransfer/src/main/resources/applicationContext.xml
@@ -31,6 +31,7 @@
       class="org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean">
     <property name="dataSource" ref="newDb"/>
     <property name="persistenceUnitName" value="Registre" />
+    <property name="persistenceXmlLocation" value="classpath:META-INF/transfer-persistence.xml"/>
   </bean>
 
   <bean id="oldDb" class="org.springframework.jdbc.datasource.SimpleDriverDataSource">

--- a/DataTransfer/src/test/java/fr/elimerl/registre/transfer/DataTransferTest.java
+++ b/DataTransfer/src/test/java/fr/elimerl/registre/transfer/DataTransferTest.java
@@ -65,6 +65,9 @@ public class DataTransferTest {
       ScriptUtils.executeSqlScript (connection, new EncodedResource (
           new ClassPathResource ("hsql-schema.sql"), StandardCharsets.UTF_8
       ));
+      ScriptUtils.executeSqlScript (connection, new EncodedResource (
+          new ClassPathResource ("modify-schema-for-migration.sql"), StandardCharsets.UTF_8
+      ));
     }
 
     DataTransfer.main (new String[0]);
@@ -283,12 +286,12 @@ public class DataTransferTest {
             .isEqualTo (parse ("2017-04-29T15:17:43"));
 
         assertThat (rs.next ()).isTrue ();
-        assertThat (rs.getLong ("id")).isEqualTo (8);
+        assertThat (rs.getLong ("id")).isEqualTo (9);
         assertThat (rs.getString ("title")).isEqualTo ("Happy new year!");
         assertThat (rs.getString ("dtype")).isEqualTo ("Book");
         assertThat (rs.getObject ("series")).isEqualTo (SERIES_WISH);
         assertThat (rs.getString ("comment")).isNull ();
-        assertThat (rs.getString ("picture")).isEqualTo ("8.jpg");
+        assertThat (rs.getString ("picture")).isEqualTo ("9.jpg");
         assertThat (rs.getObject ("owner")).isEqualTo (OWNER_ALICE);
         assertThat (rs.getObject ("location")).isNull ();
         assertThat (getBoolean (rs, "action_style")).isNull ();
@@ -395,7 +398,7 @@ public class DataTransferTest {
         assertThat (rs.getObject ("author")).isEqualTo (AUTHOR_FOO);
 
         assertThat (rs.next ()).isTrue ();
-        assertThat (rs.getLong ("id")).isEqualTo (8);
+        assertThat (rs.getLong ("id")).isEqualTo (9);
         assertThat (rs.getObject ("author")).isEqualTo (AUTHOR_FOO);
 
         assertThat (rs.next ()).isFalse ();

--- a/DataTransfer/src/test/resources/modify-schema-for-migration.sql
+++ b/DataTransfer/src/test/resources/modify-schema-for-migration.sql
@@ -1,0 +1,2 @@
+alter table records
+alter column id drop generated;

--- a/DataTransfer/src/test/resources/test-data.sql
+++ b/DataTransfer/src/test/resources/test-data.sql
@@ -7,7 +7,8 @@ insert into tout (titre, type) values (
   ('I’m the worst', 'DVD'),                 -- 5
   ('Happy Birthday', 'BD'),                 -- 6
   ('Merry Christmas', 'disque Blu-ray'),    -- 7
-  ('Happy new year!', 'livre')              -- 8
+  ('To DELETE', 'DVD'),                     -- 8
+  ('Happy new year!', 'livre')              -- 9
 );
 
 insert into films (id, realisateur, compositeur) values (
@@ -34,36 +35,38 @@ insert into bd (id, dessinateur, scenariste, numero) values (
 
 insert into livres (id, auteur) values (
   (2, 'Foo'),
-  (8, 'Foo')
+  (9, 'Foo')
 );
 
 update tout set serie = 'Me' where id in (3, 4, 5);
-update tout set serie = 'Wish' where id in (6, 7, 8);
-update tout set proprietaire = 'Alice' where id in (1, 2, 8);
+update tout set serie = 'Wish' where id in (6, 7, 9);
+update tout set proprietaire = 'Alice' where id in (1, 2, 9);
 update tout set proprietaire = 'Bob' where id in (4, 5);
 update tout set emplacement = 'Paris' where id in (2, 3);
 update tout set emplacement = 'New-York' where id in (5, 7);
 update tout set commentaire = 'Hello World!' where id = 0;
 update tout set commentaire = 'This is bad' where id = 5;
-update tout set image = 'YES' where id in (0, 1, 6, 7, 8);
+update tout set image = 'YES' where id in (0, 1, 6, 7, 9);
 update tout set createur = 'Système' where id in (0, 1, 2, 3);
 update tout set createur = 'Alice' where id in (4, 6, 7);
-update tout set createur = 'Bob' where id in (5, 8);
+update tout set createur = 'Bob' where id in (5, 9);
 update tout set creation = '2017-01-12 22:33:41' where id in (0, 1, 2, 3);
 update tout set creation = '2017-02-14 07:12:28' where id = 4;
 update tout set creation = '2017-03-19 14:32:25' where id = 5;
 update tout set creation = '2017-04-21 19:56:02' where id = 6;
 update tout set creation = '2017-04-29 15:17:43' where id = 7;
-update tout set creation = '2017-05-06 04:23:12' where id = 8;
+update tout set creation = '2017-05-06 04:23:12' where id = 9;
 update tout set dernier_editeur = 'Alice' where id in (3, 4, 5);
-update tout set dernier_editeur = 'Bob' where id in (1, 2, 8);
+update tout set dernier_editeur = 'Bob' where id in (1, 2, 9);
 update tout set derniere_edition = '2017-07-01 14:28:05' where id = 1;
 update tout set derniere_edition = '2017-07-02 11:25:31' where id = 2;
 update tout set derniere_edition = '2017-07-03 12:29:34' where id = 3;
 update tout set derniere_edition = '2017-07-04 05:18:21' where id = 4;
 update tout set derniere_edition = '2017-07-05 16:14:30' where id = 5;
-update tout set derniere_edition = '2017-07-08 15:14:32' where id = 8;
+update tout set derniere_edition = '2017-07-08 15:14:32' where id = 9;
 
 update films set genres = 'action,fantastique' where id = 0;
 update films set genres = 'film de guerre,historique' where id = 1;
 update livres set genres = 'policier' where id = 2;
+
+delete from tout where id = 8;

--- a/dependencyVersions
+++ b/dependencyVersions
@@ -5,7 +5,6 @@ org.slf4j:slf4j-api = 1.7.15
 org.slf4j:slf4j-log4j12 = $org.slf4j:slf4j-api
 org.slf4j:jul-to-slf4j = $org.slf4j:slf4j-api
 
-org.javassist:javassist = 3.22.0-GA
 javax:javaee-web-api = 7.0
 org.eclipse.persistence:org.eclipse.persistence.jpa = 2.7.0
 org.mitre:openid-connect-client = 1.3.1


### PR DESCRIPTION
The `Record` class has a `@GeneratedValue` annotation that makes EclispeLink to ignore the manually set ID. We used to remove this annotation with Javassist, which might work with Hibernate, but obviously won’t do the trick with EclipseLink.

So now, this annotation is removed with an `orm.xml` file.

Resolves #58.